### PR TITLE
New deleted_revenue_entries endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.1
+  * Add `deleted_revenue_entries` stream. Fix `singer-check-tap` issues with `contracts` date-time fields.
+
 ## 1.1.0
   * Add `deleted_` streams for deleted `contracts`, `invoices`, and `transactions` [#2](https://github.com/singer-io/tap-saasoptics/pull/2)
 

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-saasoptics',
-      version='1.1.0',
+      version='1.1.1',
       description='Singer.io tap for extracting data from the SaaSOptics v1.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_saasoptics'],
       install_requires=[
           'backoff==1.8.0',
-          'requests==2.22.0',
-          'singer-python==5.8.1'
+          'requests==2.23.0',
+          'singer-python==5.9.0'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_saasoptics/schemas/contracts.json
+++ b/tap_saasoptics/schemas/contracts.json
@@ -79,16 +79,37 @@
           "type": ["null", "string"]
         },
         "job_end_date": {
-          "type": ["null", "string"],
-          "format": "date-time"
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "format": "date-time"
+            }
+          ]
         },
         "job_projected_end_date": {
-          "type": ["null", "string"],
-          "format": "date-time"
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "format": "date-time"
+            }
+          ]
         },
         "job_start_date": {
-          "type": ["null", "string"],
-          "format": "date-time"
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "format": "date-time"
+            }
+          ]
         },
         "job_status": {
           "type": ["null", "string"]
@@ -159,8 +180,15 @@
       "type": ["null", "string"]
     },
     "entry_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
     },
     "id": {
       "type": ["null", "integer"]
@@ -169,15 +197,29 @@
       "type": ["null", "boolean"]
     },
     "lead_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
     },
     "lead_source": {
       "type": ["null", "string"]
     },
     "modified": {
-      "type": ["null", "string"],
-      "format": "date-time"
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "format": "date-time"
+        }
+      ]
     },
     "notes": {
       "type": ["null", "string"]

--- a/tap_saasoptics/schemas/deleted_revenue_entries.json
+++ b/tap_saasoptics/schemas/deleted_revenue_entries.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "deleted": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "id": {
+      "type": ["null", "integer"]
+    },
+    "deleted_by": {
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/tap_saasoptics/streams.py
+++ b/tap_saasoptics/streams.py
@@ -126,5 +126,12 @@ STREAMS = {
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['deleted'],
         'bookmark_type': 'datetime'
+    },
+    'deleted_revenue_entries': {
+        'path': 'revenue_entries/deleted',
+        'key_properties': ['id'],
+        'replication_method': 'INCREMENTAL',
+        'replication_keys': ['deleted'],
+        'bookmark_type': 'datetime'
     }
 }


### PR DESCRIPTION
# Description of change
Add `deleted_revenue_entries` stream. Fix `singer-check-tap` issues with `contracts` date-time fields.

# Manual QA steps
Added endpoint. Ran singer-discover, singer-check-tap, fixed JSON schema date-time issue with NULL dates. Then re-ran singer-check-tap, target-stitch (both initial load and incremental sync). No issues.
 
# Risks
 Currently in production. Low risk. Adds a new endpoint requested by client.
 
# Rollback steps
Revert to v.1.1.0
