### PR TITLE
Added stream access check in discovery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,24 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-saasoptics/lib/python3.12/site-packages/tap_saasoptics/schemas/*.json
       - run:
-          name: 'Unit Tests'
+          name: 'Unit Tests & Coverage Run'
           command: |
             source /usr/local/share/virtualenvs/tap-saasoptics/bin/activate
-            python -m pytest tests/unittests
+            uv pip install pytest coverage
+            mkdir -p test_output
+            coverage run -m pytest tests --junitxml=test_output/report.xml
+      - run:
+          name: 'Coverage Report'
+          command: |
+            source /usr/local/share/virtualenvs/tap-saasoptics/bin/activate
+            coverage report -m | tee coverage.txt
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - store_artifacts:
+          path: coverage.txt
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-saasoptics/lib/python3.9/site-packages/tap_saasoptics/schemas/*.json
+            stitch-validate-json /usr/local/share/virtualenvs/tap-saasoptics/lib/python3.12/site-packages/tap_saasoptics/schemas/*.json
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-saasoptics
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-saasoptics
             source /usr/local/share/virtualenvs/tap-saasoptics/bin/activate
             uv pip install -U pip setuptools
             uv pip install .[dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,16 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-saasoptics/lib/python3.12/site-packages/tap_saasoptics/schemas/*.json
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-saasoptics/bin/activate
+            python -m pytest tests/unittests
+      - run:
+          name: 'Integration Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-saasoptics/bin/activate
+            python -m pytest tests --ignore=tests/unittests
 workflows:
   version: 2
   commit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.3.0
-  * Exclude inaccessible streams during discovery and fail discovery when no streams are accessible. [#16] (http://github.com/singer-io/tap-saasoptics/pull/16)
+  * Exclude inaccessible streams during discovery and fail discovery when no streams are accessible. [#16](https://github.com/singer-io/tap-saasoptics/pull/16)
 
 ## 1.2.0
   * Upgrade python version to 3.12 [#12](https://github.com/singer-io/tap-saasoptics/pull/12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.3.0
-  * Exclude inaccessible streams during discovery and fail discovery when no streams are accessible.
+  * Exclude inaccessible streams during discovery and fail discovery when no streams are accessible. [#16] (http://github.com/singer-io/tap-saasoptics/pull/16)
 
 ## 1.2.0
   * Upgrade python version to 3.12 [#12](https://github.com/singer-io/tap-saasoptics/pull/12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+  * Exclude inaccessible streams during discovery and fail discovery when no streams are accessible.
+
 ## 1.2.0
   * Upgrade python version to 3.12 [#12](https://github.com/singer-io/tap-saasoptics/pull/12)
   * Add mock-integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+  * Upgrade python version to 3.12 [#12](https://github.com/singer-io/tap-saasoptics/pull/12)
+  * Add mock-integration tests
+
 ## 1.1.2
   * Bump depenedencies [#10](https://github.com/singer-io/tap-saasoptics/pull/10)
 

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup(name='tap-saasoptics',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_saasoptics'],
       install_requires=[
-          'backoff==1.10.0',
+          'backoff==2.2.1',
           'requests==2.32.4',
-          'singer-python==5.13.2'
+          'singer-python==6.8.0'
       ],
       entry_points='''
           [console_scripts]
@@ -19,8 +19,8 @@ setup(name='tap-saasoptics',
       ''',
       extras_require={
           'dev': [
-              'pylint==4.0.5',
-              'pytest==9.0.2'
+              'pylint',
+              'pytest'
           ]
       },
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,12 @@ setup(name='tap-saasoptics',
           [console_scripts]
           tap-saasoptics=tap_saasoptics:main
       ''',
+      extras_require={
+          'dev': [
+              'pylint==4.0.5',
+              'pytest==9.0.2'
+          ]
+      },
       packages=find_packages(),
       package_data={
           'tap_saasoptics': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-saasoptics',
-      version='1.1.2',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the SaaSOptics v1.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-saasoptics',
       py_modules=['tap_saasoptics'],
       install_requires=[
           'backoff==2.2.1',
-          'requests==2.32.4',
+          'requests==2.34.2',
           'singer-python==6.8.0'
       ],
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-saasoptics',
-      version='1.2.0',
+    version='1.3.0',
       description='Singer.io tap for extracting data from the SaaSOptics v1.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-saasoptics',
-    version='1.3.0',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the SaaSOptics v1.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_saasoptics/__init__.py
+++ b/tap_saasoptics/__init__.py
@@ -19,10 +19,10 @@ REQUIRED_CONFIG_KEYS = [
     'user_agent'
 ]
 
-def do_discover():
+def do_discover(client):
 
     LOGGER.info('Starting discover')
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 
@@ -42,7 +42,7 @@ def main():
             state = parsed_args.state
 
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(client=client,
                  config=parsed_args.config,

--- a/tap_saasoptics/client.py
+++ b/tap_saasoptics/client.py
@@ -128,11 +128,11 @@ class SaaSOpticsClient(object):
                 # Simple endpoint that returns 1 Account record (to check API/token access):
                 url='{}/{}/'.format(self.base_url, 'billing_descriptions'),
                 headers=headers)
-        except requests.RequestException:
+        except requests.RequestException as exc:
             raise SaaSOpticsError(
                 'Failed to validate SaaSOptics credentials and API endpoint. '
-                'Verify token, account_name, server_subdomain, and TLS/network configuration. '
-                )
+                'Verify token, account_name, server_subdomain, and TLS/network configuration.'
+            ) from exc
         if response.status_code != 200:
             LOGGER.error('Error status_code = {}'.format(response.status_code))
             raise_for_error(response)

--- a/tap_saasoptics/client.py
+++ b/tap_saasoptics/client.py
@@ -54,7 +54,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     402: SaaSOpticsPaymentRequiredError,
     403: SaaSOpticsForbiddenError,
     404: SaaSOpticsNotFoundError,
-    409: SaaSOpticsForbiddenError,
+    409: SaaSOpticsConflictError,
     500: SaaSOpticsInternalServiceError}
 
 
@@ -71,13 +71,14 @@ def raise_for_error(response):
                 # There is nothing we can do here since SaaSOptics has neither sent
                 # us a 2xx response nor a response content.
                 return
+            status_code = response.status_code
             response = response.json()
             if ('error' in response) or ('errorCode' in response):
                 message = '%s: %s' % (response.get('error', str(error)),
                                       response.get('message', 'Unknown Error'))
                 error_code = response.get('error', {}).get('code')
                 ex = get_exception_for_error_code(error_code)
-                if response.status_code == 401 and 'Expired token' in message:
+                if status_code == 401 and 'Expired token' in message:
                     LOGGER.error("Your API token has expired as per SaaSOptics’s security \
                         policy. \n Please re-authenticate your connection to generate a new token \
                         and resume extraction.")

--- a/tap_saasoptics/client.py
+++ b/tap_saasoptics/client.py
@@ -130,8 +130,7 @@ class SaaSOpticsClient(object):
                 headers=headers)
         except requests.RequestException:
             raise SaaSOpticsError(
-                'Failed to validate SaaSOptics credentials and API endpoint. '
-                'Verify token, account_name, server_subdomain, and TLS/network configuration. '
+                'Invalid SaaSOptics credentials or API endpoint. Check token, account_name, server_subdomain, and network config.'
                 )
         if response.status_code != 200:
             LOGGER.error('Error status_code = {}'.format(response.status_code))

--- a/tap_saasoptics/client.py
+++ b/tap_saasoptics/client.py
@@ -123,10 +123,16 @@ class SaaSOpticsClient(object):
             headers['User-Agent'] = self.__user_agent
         headers['Authorization'] = 'Token {}'.format(self.__token)
         headers['Accept'] = 'application/json'
-        response = self.__session.get(
-            # Simple endpoint that returns 1 Account record (to check API/token access):
-            url='{}/{}/'.format(self.base_url, 'billing_descriptions'),
-            headers=headers)
+        try:
+            response = self.__session.get(
+                # Simple endpoint that returns 1 Account record (to check API/token access):
+                url='{}/{}/'.format(self.base_url, 'billing_descriptions'),
+                headers=headers)
+        except requests.RequestException:
+            raise SaaSOpticsError(
+                'Failed to validate SaaSOptics credentials and API endpoint. '
+                'Verify token, account_name, server_subdomain, and TLS/network configuration. '
+                )
         if response.status_code != 200:
             LOGGER.error('Error status_code = {}'.format(response.status_code))
             raise_for_error(response)

--- a/tap_saasoptics/discover.py
+++ b/tap_saasoptics/discover.py
@@ -8,51 +8,82 @@ LOGGER = singer.get_logger()
 
 
 def _check_stream_access(client, stream_name, stream_config):
+    """Return True when stream is accessible, False on 403."""
     path = stream_config.get('path', stream_name)
-    client.get(path, endpoint=f'discover:{stream_name}')
-
-
-def _apply_access_checks(client, streams):
-    if client is None:
-        return streams
-
-    accessible = []
-    inaccessible = []
-
-    for stream_name, stream_config in streams:
-        try:
-            _check_stream_access(client, stream_name, stream_config)
-            accessible.append((stream_name, stream_config))
-        except SaaSOpticsForbiddenError as exc:
-            LOGGER.warning(
-                "Permission Error: Stream '%s' - %s",
-                stream_name,
-                exc,
-            )
-            inaccessible.append(stream_name)
-
-    if inaccessible:
+    try:
+        client.get(path, endpoint=f'discover:{stream_name}')
+        return True
+    except SaaSOpticsForbiddenError:
         LOGGER.warning(
-            'Unauthorized streams excluded from catalog: %s',
-            ', '.join(inaccessible)
+            "No 'read' access to stream '%s'. Excluded from catalog.",
+            stream_name,
         )
+        return False
 
-    if not accessible:
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> list:
+    """Remove child streams when their parent stream is inaccessible."""
+    inaccessible_children = []
+    for stream_name, stream_cfg in list(STREAMS.items()):
+        parent = stream_cfg.get('parent')
+        if stream_name in schemas and parent and parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                stream_name,
+                parent,
+            )
+            schemas.pop(stream_name, None)
+            field_metadata.pop(stream_name, None)
+            inaccessible_children.append(stream_name)
+
+    return inaccessible_children
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """Exclude streams the credentials cannot read (403) from discovery output."""
+    if client is None:
+        return
+
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_cfg in STREAMS.items()
+        if stream_name in schemas
+        and not stream_cfg.get('parent')
+        and not _check_stream_access(client, stream_name, stream_cfg)
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    inaccessible_children = _prune_inaccessible_children(schemas, field_metadata)
+    all_inaccessible = inaccessible_streams + [
+        stream_name
+        for stream_name in inaccessible_children
+        if stream_name not in inaccessible_streams
+    ]
+
+    if not schemas:
         raise SaaSOpticsForbiddenError(
-            'No streams are accessible. Verify API permissions for the configured token.'
+            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
         )
 
-    return accessible
+    if all_inaccessible:
+        LOGGER.warning(
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            ', '.join(all_inaccessible),
+        )
 
 
 def discover(client=None):
     schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
     catalog = Catalog([])
 
-    stream_items = list(STREAMS.items())
-    for stream_name, stream_metadata in _apply_access_checks(client, stream_items):
-        schema = Schema.from_dict(schemas[stream_name])
+    for stream_name, schema_dict in schemas.items():
+        schema = Schema.from_dict(schema_dict)
         mdata = field_metadata[stream_name]
+        stream_metadata = STREAMS.get(stream_name, {})
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,

--- a/tap_saasoptics/discover.py
+++ b/tap_saasoptics/discover.py
@@ -13,10 +13,11 @@ def _check_stream_access(client, stream_name, stream_config):
     try:
         client.get(path, endpoint=f'discover:{stream_name}')
         return True
-    except SaaSOpticsForbiddenError:
+    except SaaSOpticsForbiddenError as exc:
         LOGGER.warning(
-            "No 'read' access to stream '%s'. Excluded from catalog.",
+            "Excluding unauthorized stream '%s' from catalog. API error: %s",
             stream_name,
+            exc,
         )
         return False
 
@@ -70,7 +71,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
 
     if all_inaccessible:
         LOGGER.warning(
-            "No 'read' access to stream(s): %s. Excluded from catalog.",
+            "Excluding unauthorized stream(s) from catalog: %s.",
             ', '.join(all_inaccessible),
         )
 

--- a/tap_saasoptics/discover.py
+++ b/tap_saasoptics/discover.py
@@ -9,7 +9,7 @@ LOGGER = singer.get_logger()
 
 def _check_stream_access(client, stream_name, stream_config):
     path = stream_config.get('path', stream_name)
-    client.get(path=path)
+    client.get(path, endpoint=f'discover:{stream_name}')
 
 
 def _apply_access_checks(client, streams):

--- a/tap_saasoptics/discover.py
+++ b/tap_saasoptics/discover.py
@@ -23,7 +23,12 @@ def _apply_access_checks(client, streams):
         try:
             _check_stream_access(client, stream_name, stream_config)
             accessible.append((stream_name, stream_config))
-        except SaaSOpticsForbiddenError:
+        except SaaSOpticsForbiddenError as exc:
+            LOGGER.warning(
+                "Permission Error: Stream '%s' - %s",
+                stream_name,
+                exc,
+            )
             inaccessible.append(stream_name)
 
     if inaccessible:

--- a/tap_saasoptics/discover.py
+++ b/tap_saasoptics/discover.py
@@ -27,7 +27,10 @@ def _apply_access_checks(client, streams):
             inaccessible.append(stream_name)
 
     if inaccessible:
-        LOGGER.warning('Skipping inaccessible streams: %s', ', '.join(inaccessible))
+        LOGGER.warning(
+            'Unauthorized streams excluded from catalog: %s',
+            ', '.join(inaccessible)
+        )
 
     if not accessible:
         raise SaaSOpticsForbiddenError(

--- a/tap_saasoptics/discover.py
+++ b/tap_saasoptics/discover.py
@@ -83,7 +83,7 @@ def discover(client=None):
     for stream_name, schema_dict in schemas.items():
         schema = Schema.from_dict(schema_dict)
         mdata = field_metadata[stream_name]
-        stream_metadata = STREAMS.get(stream_name, {})
+        stream_metadata = STREAMS[stream_name]
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,

--- a/tap_saasoptics/discover.py
+++ b/tap_saasoptics/discover.py
@@ -1,18 +1,55 @@
+import singer
 from singer.catalog import Catalog, CatalogEntry, Schema
-from tap_saasoptics.schema import get_schemas, STREAMS
 
-def discover():
+from tap_saasoptics.client import SaaSOpticsForbiddenError
+from tap_saasoptics.schema import STREAMS, get_schemas
+
+LOGGER = singer.get_logger()
+
+
+def _check_stream_access(client, stream_name, stream_config):
+    path = stream_config.get('path', stream_name)
+    client.get(path=path)
+
+
+def _apply_access_checks(client, streams):
+    if client is None:
+        return streams
+
+    accessible = []
+    inaccessible = []
+
+    for stream_name, stream_config in streams:
+        try:
+            _check_stream_access(client, stream_name, stream_config)
+            accessible.append((stream_name, stream_config))
+        except SaaSOpticsForbiddenError:
+            inaccessible.append(stream_name)
+
+    if inaccessible:
+        LOGGER.warning('Skipping inaccessible streams: %s', ', '.join(inaccessible))
+
+    if not accessible:
+        raise SaaSOpticsForbiddenError(
+            'No streams are accessible. Verify API permissions for the configured token.'
+        )
+
+    return accessible
+
+
+def discover(client=None):
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
 
-    for stream_name, schema_dict in schemas.items():
-        schema = Schema.from_dict(schema_dict)
+    stream_items = list(STREAMS.items())
+    for stream_name, stream_metadata in _apply_access_checks(client, stream_items):
+        schema = Schema.from_dict(schemas[stream_name])
         mdata = field_metadata[stream_name]
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,
             tap_stream_id=stream_name,
-            key_properties=STREAMS[stream_name]['key_properties'],
+            key_properties=stream_metadata['key_properties'],
             schema=schema,
             metadata=mdata
         ))

--- a/tap_saasoptics/schema.py
+++ b/tap_saasoptics/schema.py
@@ -30,6 +30,16 @@ def get_schemas():
             valid_replication_keys=stream_metadata.get('replication_keys', None),
             replication_method=stream_metadata.get('replication_method', None)
         )
+        replication_keys = stream_metadata.get('replication_keys', []) or []
+        mdata = metadata.to_map(mdata)
+        for replication_key in replication_keys:
+            mdata = metadata.write(
+                mdata,
+                ('properties', replication_key),
+                'inclusion',
+                'automatic'
+            )
+        mdata = metadata.to_list(mdata)
         field_metadata[stream_name] = mdata
 
     return schemas, field_metadata

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,232 @@
+from tap_saasoptics.schema import get_schemas
+
+
+class SaaSOpticsBaseTest:
+    """
+    Base class for tap-saasoptics mock integration tests.
+
+    Provides expected stream metadata, setUp/tearDown helpers, and utilities
+    for generating schema-valid mock records without hitting the real API.
+    """
+
+    default_start_date = "2025-01-01T00:00:00Z"
+
+    # Constants used as keys in expected_metadata()
+    PRIMARY_KEYS = "primary_keys"
+    REPLICATION_METHOD = "replication_method"
+    REPLICATION_KEYS = "replication_keys"
+    OBEYS_START_DATE = "obeys_start_date"
+
+    @classmethod
+    def expected_metadata(cls):
+        """Return a dict of stream_name -> expected Singer metadata properties."""
+        return {
+            "customers": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"modified"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "contracts": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"modified"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "invoices": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"auditentry_modified"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "items": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"modified"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "transactions": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"modified"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "billing_descriptions": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "accounts": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "auto_renewal_profiles": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "billing_methods": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "country_codes": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "currency_codes": {
+                cls.PRIMARY_KEYS: {"code"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "payment_terms": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "registers": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"modified"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "revenue_entries": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"modified"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "revenue_recognition_methods": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "sales_orders": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "FULL_TABLE",
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: False,
+            },
+            "deleted_contracts": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"deleted"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "deleted_transactions": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"deleted"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "deleted_invoices": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"deleted"},
+                cls.OBEYS_START_DATE: True,
+            },
+            "deleted_revenue_entries": {
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: "INCREMENTAL",
+                cls.REPLICATION_KEYS: {"deleted"},
+                cls.OBEYS_START_DATE: True,
+            },
+        }
+
+    def setUp(self):
+        """Populate self.config and self.state with safe test defaults."""
+        self.config = {
+            "token": "dummy-token",
+            "account_name": "dummy-account",
+            "server_subdomain": "dummy-subdomain",
+            "user_agent": "test-agent/1.0",
+            "start_date": self.default_start_date,
+        }
+        self.state = {}
+
+    # ------------------------------------------------------------------
+    # Schema-aware mock-data helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _schema_type(schema):
+        """Return the concrete JSON-schema type, collapsing null-unions."""
+        schema_type = schema.get("type", "object")
+        if isinstance(schema_type, list):
+            non_null = [t for t in schema_type if t != "null"]
+            return non_null[0] if non_null else "null"
+        return schema_type
+
+    @staticmethod
+    def _generate_value(schema, date_value="2025-01-01T00:00:00Z"):
+        """Recursively generate one valid mock value for a JSON-schema fragment."""
+        # Handle anyOf by choosing the first non-null sub-schema.
+        # This covers fields like {"anyOf": [{"type": "null"}, {"type": "string",
+        # "format": "date-time"}]} which have no top-level "type" key.
+        if "anyOf" in schema:
+            non_null = [
+                s for s in schema["anyOf"]
+                if s.get("type") != "null"
+            ]
+            if non_null:
+                return SaaSOpticsBaseTest._generate_value(
+                    non_null[0], date_value=date_value
+                )
+            return None
+
+        if "enum" in schema and schema["enum"]:
+            return schema["enum"][0]
+
+        schema_type = SaaSOpticsBaseTest._schema_type(schema)
+
+        if schema_type == "object":
+            properties = schema.get("properties", {})
+            required = set(schema.get("required", []))
+            return {
+                key: SaaSOpticsBaseTest._generate_value(val, date_value=date_value)
+                for key, val in properties.items()
+                if key in required
+                or SaaSOpticsBaseTest._schema_type(val) != "null"
+            }
+
+        if schema_type == "array":
+            item_schema = schema.get("items", {"type": "string"})
+            return [SaaSOpticsBaseTest._generate_value(
+                item_schema, date_value=date_value
+            )]
+
+        if schema_type == "string":
+            fmt = schema.get("format")
+            if fmt == "date-time":
+                return date_value
+            if fmt == "email":
+                return "mock@example.com"
+            return "mock"
+
+        return {"integer": 1, "number": 1.0, "boolean": True}.get(schema_type)
+
+    @staticmethod
+    def _generate_stream_record(stream_name, date_value="2025-01-01T00:00:00Z"):
+        """Generate one schema-valid record dict for the given stream."""
+        schemas, _ = get_schemas()
+        return SaaSOpticsBaseTest._generate_value(
+            schemas[stream_name], date_value=date_value
+        )
+
+    def _make_client_response(self, records, next_url=None):
+        """Return a dict that mimics a paginated SaaSOptics API page response."""
+        return {
+            "count": len(records),
+            "next": next_url,
+            "results": records,
+        }

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -1,0 +1,154 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from tap_saasoptics.discover import discover
+from tap_saasoptics.streams import STREAMS
+from tap_saasoptics.sync import sync
+
+try:
+    from .base import SaaSOpticsBaseTest
+except ImportError:
+    from base import SaaSOpticsBaseTest
+
+
+class AllFieldsIntegrationTest(SaaSOpticsBaseTest, unittest.TestCase):
+    """
+    Integration tests that verify every selected stream is synced and
+    that Singer write_record is called with schema-valid records.
+    """
+
+    # ------------------------------------------------------------------
+    # Helper: build a mock client whose .get() always returns one record
+    # ------------------------------------------------------------------
+
+    def _build_mock_client(self, stream_name, record, next_url=None):
+        """
+        Return a MagicMock SaaSOpticsClient whose get() returns a single-page
+        response containing *record*.
+        """
+        mock_client = MagicMock()
+        mock_client.base_url = "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        mock_client.get.return_value = self._make_client_response([record], next_url)
+        return mock_client
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_record")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.sync_endpoint")
+    def test_sync_calls_sync_endpoint_for_every_selected_stream(
+        self,
+        mock_sync_endpoint,
+        _mock_write_schema,
+        _mock_write_record,
+        _mock_write_state,
+    ):
+        """sync() must call sync_endpoint once per selected stream."""
+        mock_sync_endpoint.return_value = 1
+
+        catalog = discover()
+        catalog.get_selected_streams = lambda _state: catalog.streams
+
+        mock_client = MagicMock()
+        sync(client=mock_client, config=self.config, catalog=catalog, state=self.state)
+
+        self.assertEqual(mock_sync_endpoint.call_count, len(STREAMS))
+
+        synced_streams = {
+            c.kwargs["stream_name"] for c in mock_sync_endpoint.call_args_list
+        }
+        self.assertEqual(synced_streams, set(STREAMS.keys()))
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_record")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.transform_json")
+    def test_every_stream_produces_at_least_one_record(
+        self,
+        mock_transform_json,
+        _mock_write_schema,
+        mock_write_record,
+        _mock_write_state,
+    ):
+        """
+        For each stream, sync_endpoint must call write_record at least once
+        when the API returns a valid mock record.
+        """
+        from tap_saasoptics.sync import sync_endpoint
+
+        for stream_name, endpoint_config in STREAMS.items():
+            with self.subTest(stream=stream_name):
+                record = self._generate_stream_record(stream_name)
+                mock_transform_json.return_value = [record]
+
+                mock_client = MagicMock()
+                mock_client.base_url = (
+                    "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+                )
+                mock_client.get.return_value = self._make_client_response([record])
+
+                catalog = discover()
+                state = {}
+                mock_write_record.reset_mock()
+
+                sync_endpoint(
+                    client=mock_client,
+                    catalog=catalog,
+                    state=state,
+                    start_date=self.default_start_date,
+                    stream_name=stream_name,
+                    path=endpoint_config.get("path", stream_name),
+                    endpoint_config=endpoint_config,
+                    static_params=endpoint_config.get("params", {}),
+                    bookmark_query_field_from=endpoint_config.get(
+                        "bookmark_query_field_from"
+                    ),
+                    bookmark_query_field_to=endpoint_config.get(
+                        "bookmark_query_field_to"
+                    ),
+                    bookmark_field=next(
+                        iter(endpoint_config.get("replication_keys", [])), None
+                    ),
+                    bookmark_type=endpoint_config.get("bookmark_type"),
+                    data_key=endpoint_config.get("data_key", "results"),
+                    id_fields=endpoint_config.get("key_properties"),
+                    days_interval=60,
+                )
+
+                self.assertGreater(
+                    mock_write_record.call_count,
+                    0,
+                    msg=f"Stream '{stream_name}': no records were written",
+                )
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_record")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.sync_endpoint")
+    def test_sync_respects_selected_streams_subset(
+        self,
+        mock_sync_endpoint,
+        _mock_write_schema,
+        _mock_write_record,
+        _mock_write_state,
+    ):
+        """sync() must only call sync_endpoint for streams in the selection."""
+        mock_sync_endpoint.return_value = 0
+
+        selected = ["customers", "contracts"]
+        catalog = discover()
+        catalog.get_selected_streams = lambda _state: [
+            s for s in catalog.streams if s.stream in selected
+        ]
+
+        mock_client = MagicMock()
+        sync(client=mock_client, config=self.config, catalog=catalog, state=self.state)
+
+        self.assertEqual(mock_sync_endpoint.call_count, len(selected))
+        synced_streams = {
+            c.kwargs["stream_name"] for c in mock_sync_endpoint.call_args_list
+        }
+        self.assertEqual(synced_streams, set(selected))

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,0 +1,140 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_saasoptics.discover import discover
+from tap_saasoptics.streams import STREAMS
+from tap_saasoptics.sync import sync_endpoint
+
+try:
+    from .base import SaaSOpticsBaseTest
+except ImportError:
+    from base import SaaSOpticsBaseTest
+
+
+class AutomaticFieldsIntegrationTest(SaaSOpticsBaseTest, unittest.TestCase):
+    """
+    Verify that primary keys and replication keys — the minimum 'automatic'
+    fields — are always present in every synced record, without relying on
+    schema.py marking them as automatic.
+    """
+
+    # ------------------------------------------------------------------
+    # Helper
+    # ------------------------------------------------------------------
+
+    def _run_sync_endpoint(self, stream_name, record):
+        """Run sync_endpoint for *stream_name* with a single mocked record."""
+        endpoint_config = STREAMS[stream_name]
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = self._make_client_response([record])
+
+        catalog = discover()
+
+        sync_endpoint(
+            client=mock_client,
+            catalog=catalog,
+            state={},
+            start_date=self.default_start_date,
+            stream_name=stream_name,
+            path=endpoint_config.get("path", stream_name),
+            endpoint_config=endpoint_config,
+            static_params=endpoint_config.get("params", {}),
+            bookmark_query_field_from=endpoint_config.get("bookmark_query_field_from"),
+            bookmark_query_field_to=endpoint_config.get("bookmark_query_field_to"),
+            bookmark_field=next(
+                iter(endpoint_config.get("replication_keys", [])), None
+            ),
+            bookmark_type=endpoint_config.get("bookmark_type"),
+            data_key=endpoint_config.get("data_key", "results"),
+            id_fields=endpoint_config.get("key_properties"),
+            days_interval=3650,
+        )
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_record")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.transform_json")
+    def test_primary_keys_present_in_every_synced_record(
+        self,
+        mock_transform_json,
+        _mock_write_schema,
+        mock_write_record,
+        _mock_write_state,
+    ):
+        """
+        For every stream, the primary key field(s) must appear in each
+        record passed to write_record.
+        """
+        for stream_name, expected in self.expected_metadata().items():
+            with self.subTest(stream=stream_name):
+                record = self._generate_stream_record(stream_name)
+                mock_transform_json.return_value = [record]
+                mock_write_record.reset_mock()
+
+                self._run_sync_endpoint(stream_name, record)
+
+                self.assertGreater(
+                    mock_write_record.call_count,
+                    0,
+                    msg=f"Stream '{stream_name}': write_record was never called",
+                )
+                for call in mock_write_record.call_args_list:
+                    written_record = call.args[1]
+                    for pk in expected[self.PRIMARY_KEYS]:
+                        self.assertIn(
+                            pk,
+                            written_record,
+                            msg=(
+                                f"Stream '{stream_name}': primary key '{pk}' "
+                                f"missing from synced record"
+                            ),
+                        )
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_record")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.transform_json")
+    def test_replication_keys_present_in_every_incremental_stream_record(
+        self,
+        mock_transform_json,
+        _mock_write_schema,
+        mock_write_record,
+        _mock_write_state,
+    ):
+        """
+        For every INCREMENTAL stream, the replication key field must appear
+        in each record passed to write_record.
+        """
+        for stream_name, expected in self.expected_metadata().items():
+            if expected[self.REPLICATION_METHOD] != "INCREMENTAL":
+                continue
+            with self.subTest(stream=stream_name):
+                record = self._generate_stream_record(stream_name)
+                mock_transform_json.return_value = [record]
+                mock_write_record.reset_mock()
+
+                self._run_sync_endpoint(stream_name, record)
+
+                self.assertGreater(
+                    mock_write_record.call_count,
+                    0,
+                    msg=f"Stream '{stream_name}': write_record was never called",
+                )
+                for call in mock_write_record.call_args_list:
+                    written_record = call.args[1]
+                    for rep_key in expected[self.REPLICATION_KEYS]:
+                        self.assertIn(
+                            rep_key,
+                            written_record,
+                            msg=(
+                                f"Stream '{stream_name}': replication key "
+                                f"'{rep_key}' missing from synced record"
+                            ),
+                        )

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,0 +1,260 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_saasoptics.discover import discover
+from tap_saasoptics.sync import sync_endpoint
+
+try:
+    from .base import SaaSOpticsBaseTest
+except ImportError:
+    from base import SaaSOpticsBaseTest
+
+
+class BookmarkIntegrationTest(SaaSOpticsBaseTest, unittest.TestCase):
+    """
+    Integration tests for bookmark / state management.
+
+    Verifies that:
+    * An existing bookmark is forwarded as the window-start query parameter.
+    * After a successful sync the bookmark is advanced to the max record value.
+    * FULL_TABLE streams do not write a bookmark.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run_incremental_sync(self, stream_name, records, initial_bookmark=None):
+        """
+        Run sync_endpoint for an INCREMENTAL stream and return the resulting state.
+        """
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "INCREMENTAL",
+            "replication_keys": ["modified"],
+            "bookmark_query_field_from": "modified__gte",
+            "bookmark_query_field_to": "modified__lte",
+            "bookmark_type": "datetime",
+        }
+
+        state = {}
+        if initial_bookmark:
+            state["bookmarks"] = {stream_name: initial_bookmark}
+
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {
+            "count": len(records),
+            "next": None,
+            "results": records,
+        }
+
+        catalog = discover()
+
+        with patch("tap_saasoptics.sync.transform_json", side_effect=lambda d, s, p: d.get(p, [])), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state=state,
+                start_date=self.default_start_date,
+                stream_name=stream_name,
+                path=stream_name,
+                endpoint_config=endpoint_config,
+                static_params={},
+                bookmark_query_field_from="modified__gte",
+                bookmark_query_field_to="modified__lte",
+                bookmark_field="modified",
+                bookmark_type="datetime",
+                data_key="results",
+                id_fields=["id"],
+                days_interval=60,
+            )
+
+        return state, mock_client
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.transform_json")
+    def test_existing_bookmark_used_as_window_start(
+        self, mock_transform_json, _mock_write_schema, _mock_write_state
+    ):
+        """
+        When a bookmark exists in state it must be passed as the
+        bookmark_query_field_from value in the first API request.
+        """
+        existing_bookmark = "2025-06-01T00:00:00Z"
+        stream_name = "customers"
+        record = {"id": "1", "modified": "2025-06-15T00:00:00Z"}
+        mock_transform_json.return_value = [record]
+
+        state = {"bookmarks": {stream_name: existing_bookmark}}
+
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {"count": 1, "next": None, "results": [record]}
+
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "INCREMENTAL",
+            "replication_keys": ["modified"],
+            "bookmark_query_field_from": "modified__gte",
+            "bookmark_query_field_to": "modified__lte",
+            "bookmark_type": "datetime",
+        }
+
+        catalog = discover()
+        sync_endpoint(
+            client=mock_client,
+            catalog=catalog,
+            state=state,
+            start_date=self.default_start_date,
+            stream_name=stream_name,
+            path=stream_name,
+            endpoint_config=endpoint_config,
+            static_params={},
+            bookmark_query_field_from="modified__gte",
+            bookmark_query_field_to="modified__lte",
+            bookmark_field="modified",
+            bookmark_type="datetime",
+            data_key="results",
+            id_fields=["id"],
+            days_interval=3650,
+        )
+
+        # The querystring passed to client.get must contain modified__gte=<bookmark>
+        call_kwargs = mock_client.get.call_args_list[0]
+        params_str = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params", "")
+        self.assertIn(
+            "modified__gte",
+            str(params_str),
+            msg="Existing bookmark was not forwarded as modified__gte",
+        )
+        self.assertIn(
+            "2025-06-01",
+            str(params_str),
+            msg="Existing bookmark date value was not found in query params",
+        )
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.transform_json")
+    def test_bookmark_advances_after_sync(
+        self, mock_transform_json, _mock_write_schema, _mock_write_state
+    ):
+        """
+        After sync_endpoint runs, the state bookmark must be >= the initial bookmark.
+        """
+        old_bookmark = "2025-01-01T00:00:00Z"
+        stream_name = "customers"
+        records = [
+            {"id": "1", "modified": "2025-02-01T00:00:00Z"},
+            {"id": "2", "modified": "2025-03-01T00:00:00Z"},
+            {"id": "3", "modified": "2025-04-01T00:00:00Z"},
+        ]
+        mock_transform_json.return_value = records
+
+        state = {"bookmarks": {stream_name: old_bookmark}}
+
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {
+            "count": len(records),
+            "next": None,
+            "results": records,
+        }
+
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "INCREMENTAL",
+            "replication_keys": ["modified"],
+            "bookmark_query_field_from": "modified__gte",
+            "bookmark_query_field_to": "modified__lte",
+            "bookmark_type": "datetime",
+        }
+
+        catalog = discover()
+        sync_endpoint(
+            client=mock_client,
+            catalog=catalog,
+            state=state,
+            start_date=self.default_start_date,
+            stream_name=stream_name,
+            path=stream_name,
+            endpoint_config=endpoint_config,
+            static_params={},
+            bookmark_query_field_from="modified__gte",
+            bookmark_query_field_to="modified__lte",
+            bookmark_field="modified",
+            bookmark_type="datetime",
+            data_key="results",
+            id_fields=["id"],
+            days_interval=3650,
+        )
+
+        new_bookmark = state.get("bookmarks", {}).get(stream_name)
+        self.assertIsNotNone(new_bookmark, msg="Bookmark was not written to state")
+        self.assertGreaterEqual(
+            new_bookmark,
+            old_bookmark,
+            msg=f"Bookmark was not advanced: {new_bookmark!r} < {old_bookmark!r}",
+        )
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_schema")
+    @patch("tap_saasoptics.sync.transform_json")
+    def test_full_table_stream_does_not_write_bookmark(
+        self, mock_transform_json, _mock_write_schema, _mock_write_state
+    ):
+        """FULL_TABLE streams must not write a bookmark to state."""
+        stream_name = "accounts"
+        record = self._generate_stream_record(stream_name)
+        mock_transform_json.return_value = [record]
+
+        state = {}
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {"count": 1, "next": None, "results": [record]}
+
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "FULL_TABLE",
+        }
+
+        catalog = discover()
+        sync_endpoint(
+            client=mock_client,
+            catalog=catalog,
+            state=state,
+            start_date=self.default_start_date,
+            stream_name=stream_name,
+            path=stream_name,
+            endpoint_config=endpoint_config,
+            static_params={},
+            bookmark_query_field_from=None,
+            bookmark_query_field_to=None,
+            bookmark_field=None,
+            bookmark_type=None,
+            data_key="results",
+            id_fields=["id"],
+            days_interval=60,
+        )
+
+        self.assertNotIn(
+            stream_name,
+            state.get("bookmarks", {}),
+            msg="FULL_TABLE stream must not write a bookmark",
+        )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,103 @@
+import unittest
+
+from singer import metadata
+
+from tap_saasoptics.discover import discover
+
+try:
+    from .base import SaaSOpticsBaseTest
+except ImportError:
+    from base import SaaSOpticsBaseTest
+
+
+class DiscoveryIntegrationTest(SaaSOpticsBaseTest, unittest.TestCase):
+    """Integration tests for catalog discovery."""
+
+    def test_discovery_expected_streams_and_metadata(self):
+        """
+        discover() must return exactly the expected streams, and each stream's
+        root-level Singer metadata must carry correct:
+          - table-key-properties   (primary keys)
+          - forced-replication-method
+          - valid-replication-keys
+        """
+        catalog = discover()
+        stream_map = {s.tap_stream_id: s for s in catalog.streams}
+        expected_streams = self.expected_metadata()
+
+        # 1. Correct set of streams returned
+        self.assertEqual(
+            set(stream_map.keys()),
+            set(expected_streams.keys()),
+        )
+
+        for stream_name, stream_expected in expected_streams.items():
+            with self.subTest(stream=stream_name):
+                root_md = metadata.to_map(
+                    stream_map[stream_name].metadata
+                )[()]
+
+                # 2. Primary keys
+                self.assertEqual(
+                    set(root_md.get("table-key-properties", [])),
+                    stream_expected[self.PRIMARY_KEYS],
+                )
+
+                # 3. Replication method
+                self.assertEqual(
+                    root_md.get("forced-replication-method"),
+                    stream_expected[self.REPLICATION_METHOD],
+                )
+
+                # 4. Replication keys
+                raw = root_md.get("valid-replication-keys", [])
+                actual_rep_keys = (
+                    {raw} if isinstance(raw, str) else set(raw)
+                )
+                self.assertEqual(
+                    actual_rep_keys,
+                    stream_expected[self.REPLICATION_KEYS],
+                )
+
+    def test_discovery_stream_entries_have_schema(self):
+        """Every catalog entry must have a non-empty schema with 'properties'."""
+        catalog = discover()
+        for stream in catalog.streams:
+            with self.subTest(stream=stream.tap_stream_id):
+                schema_dict = stream.schema.to_dict()
+                self.assertIn(
+                    "properties",
+                    schema_dict,
+                    msg=(
+                        f"Stream '{stream.tap_stream_id}' schema "
+                        f"missing 'properties'"
+                    ),
+                )
+                self.assertGreater(
+                    len(schema_dict["properties"]),
+                    0,
+                    msg=(
+                        f"Stream '{stream.tap_stream_id}' schema "
+                        f"has empty 'properties'"
+                    ),
+                )
+
+    def test_discovery_stream_equals_tap_stream_id(self):
+        """CatalogEntry.stream must equal CatalogEntry.tap_stream_id."""
+        catalog = discover()
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                self.assertEqual(entry.stream, entry.tap_stream_id)
+
+    def test_discovery_catalog_entries_have_metadata(self):
+        """Every catalog entry must carry non-empty metadata."""
+        catalog = discover()
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                self.assertTrue(
+                    entry.metadata,
+                    msg=(
+                        f"CatalogEntry for '{entry.tap_stream_id}' "
+                        f"has no metadata"
+                    ),
+                )

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,298 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from tap_saasoptics.discover import discover
+from tap_saasoptics.sync import sync_endpoint
+
+try:
+    from .base import SaaSOpticsBaseTest
+except ImportError:
+    from base import SaaSOpticsBaseTest
+
+
+class PaginationIntegrationTest(SaaSOpticsBaseTest, unittest.TestCase):
+    """
+    Integration tests that verify sync_endpoint follows 'next' URLs and
+    accumulates records across multiple API pages.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_paginated_client(self, pages):
+        """
+        Return a MagicMock client whose get() returns pages in sequence.
+
+        *pages* is a list of (records_list, next_url_or_None) tuples.
+        """
+        base_url = "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+
+        responses = [
+            {"count": sum(len(p[0]) for p in pages), "next": nxt, "results": recs}
+            for recs, nxt in pages
+        ]
+
+        mock_client = MagicMock()
+        mock_client.base_url = base_url
+        mock_client.get.side_effect = responses
+        return mock_client
+
+    def _make_records(self, stream_name, n, start_date_offset=0):
+        """Generate *n* schema-valid records for *stream_name*."""
+        dates = [
+            f"2025-{(i + 1 + start_date_offset):02d}-01T00:00:00Z"
+            for i in range(n)
+        ]
+        return [
+            self._generate_stream_record(stream_name, date_value=d) for d in dates
+        ]
+
+    def _call_sync_endpoint(self, mock_client, catalog, state, stream_name,
+                            endpoint_config):
+        """Wrapper that calls sync_endpoint with standard INCREMENTAL config."""
+        with patch("tap_saasoptics.sync.transform_json",
+                   side_effect=lambda d, s, p: d.get(p, [])), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            return sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state=state,
+                start_date=self.default_start_date,
+                stream_name=stream_name,
+                path=endpoint_config.get("path", stream_name),
+                endpoint_config=endpoint_config,
+                static_params=endpoint_config.get("params", {}),
+                bookmark_query_field_from=endpoint_config.get(
+                    "bookmark_query_field_from"
+                ),
+                bookmark_query_field_to=endpoint_config.get(
+                    "bookmark_query_field_to"
+                ),
+                bookmark_field=next(
+                    iter(endpoint_config.get("replication_keys", [])), None
+                ),
+                bookmark_type=endpoint_config.get("bookmark_type"),
+                data_key=endpoint_config.get("data_key", "results"),
+                id_fields=endpoint_config.get("key_properties"),
+                days_interval=60,
+            )
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_pagination_all_pages_processed(self, mock_write_record):
+        """
+        When the API returns two pages, every record from both pages must
+        be written via write_record.
+        """
+        stream_name = "customers"
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "INCREMENTAL",
+            "replication_keys": ["modified"],
+            "bookmark_query_field_from": "modified__gte",
+            "bookmark_query_field_to": "modified__lte",
+            "bookmark_type": "datetime",
+        }
+
+        page1_records = [
+            {"id": "1", "modified": "2025-01-15T00:00:00Z"},
+            {"id": "2", "modified": "2025-02-15T00:00:00Z"},
+        ]
+        page2_records = [
+            {"id": "3", "modified": "2025-03-15T00:00:00Z"},
+            {"id": "4", "modified": "2025-04-15T00:00:00Z"},
+        ]
+
+        base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        page2_url = f"{base_url}/customers/?page=2"
+
+        mock_client = self._build_paginated_client([
+            (page1_records, page2_url),
+            (page2_records, None),
+        ])
+
+        catalog = discover()
+
+        with patch("tap_saasoptics.sync.transform_json",
+                   side_effect=lambda d, s, p: d.get(p, [])), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state={},
+                start_date=self.default_start_date,
+                stream_name=stream_name,
+                path=stream_name,
+                endpoint_config=endpoint_config,
+                static_params={},
+                bookmark_query_field_from="modified__gte",
+                bookmark_query_field_to="modified__lte",
+                bookmark_field="modified",
+                bookmark_type="datetime",
+                data_key="results",
+                id_fields=["id"],
+                days_interval=3650,
+            )
+
+        # client.get was called for page1 (by path) and page2 (by next url)
+        self.assertEqual(mock_client.get.call_count, 2)
+        # write_record was called for all 4 records
+        self.assertEqual(mock_write_record.call_count, 4)
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_single_page_response_processed_correctly(self, mock_write_record):
+        """
+        When the API returns a single page with no next URL, all records
+        on that page must be written and get() must be called exactly once.
+        """
+        stream_name = "items"
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "INCREMENTAL",
+            "replication_keys": ["modified"],
+            "bookmark_query_field_from": "modified__gte",
+            "bookmark_query_field_to": "modified__lte",
+            "bookmark_type": "datetime",
+        }
+        records = [
+            {"id": "1", "modified": "2025-01-10T00:00:00Z"},
+            {"id": "2", "modified": "2025-01-20T00:00:00Z"},
+            {"id": "3", "modified": "2025-01-30T00:00:00Z"},
+        ]
+
+        mock_client = self._build_paginated_client([(records, None)])
+        catalog = discover()
+
+        with patch("tap_saasoptics.sync.transform_json",
+                   side_effect=lambda d, s, p: d.get(p, [])), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state={},
+                start_date=self.default_start_date,
+                stream_name=stream_name,
+                path=stream_name,
+                endpoint_config=endpoint_config,
+                static_params={},
+                bookmark_query_field_from="modified__gte",
+                bookmark_query_field_to="modified__lte",
+                bookmark_field="modified",
+                bookmark_type="datetime",
+                data_key="results",
+                id_fields=["id"],
+                days_interval=3650,
+            )
+
+        self.assertEqual(mock_client.get.call_count, 1)
+        self.assertEqual(mock_write_record.call_count, 3)
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_empty_response_writes_no_records(self, mock_write_record):
+        """
+        When the API returns an empty results list, write_record must not
+        be called at all.
+        """
+        stream_name = "billing_descriptions"
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "FULL_TABLE",
+        }
+
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {"count": 0, "next": None, "results": []}
+
+        catalog = discover()
+
+        with patch("tap_saasoptics.sync.transform_json",
+                   side_effect=lambda d, s, p: d.get(p, [])), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state={},
+                start_date=self.default_start_date,
+                stream_name=stream_name,
+                path=stream_name,
+                endpoint_config=endpoint_config,
+                static_params={},
+                bookmark_query_field_from=None,
+                bookmark_query_field_to=None,
+                bookmark_field=None,
+                bookmark_type=None,
+                data_key="results",
+                id_fields=["id"],
+                days_interval=60,
+            )
+
+        mock_write_record.assert_not_called()
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_three_page_pagination(self, mock_write_record):
+        """Verify that three API pages are all consumed correctly."""
+        stream_name = "revenue_entries"
+        endpoint_config = {
+            "key_properties": ["id"],
+            "replication_method": "INCREMENTAL",
+            "replication_keys": ["modified"],
+            "bookmark_query_field_from": "modified__gte",
+            "bookmark_query_field_to": "modified__lte",
+            "bookmark_type": "datetime",
+        }
+
+        base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        page2_url = f"{base_url}/revenue_entries/?page=2"
+        page3_url = f"{base_url}/revenue_entries/?page=3"
+
+        page1 = [{"id": "1", "modified": "2025-01-05T00:00:00Z"}]
+        page2 = [{"id": "2", "modified": "2025-02-05T00:00:00Z"},
+                 {"id": "3", "modified": "2025-03-05T00:00:00Z"}]
+        page3 = [{"id": "4", "modified": "2025-04-05T00:00:00Z"}]
+
+        mock_client = self._build_paginated_client([
+            (page1, page2_url),
+            (page2, page3_url),
+            (page3, None),
+        ])
+
+        catalog = discover()
+
+        with patch("tap_saasoptics.sync.transform_json",
+                   side_effect=lambda d, s, p: d.get(p, [])), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state={},
+                start_date=self.default_start_date,
+                stream_name=stream_name,
+                path=stream_name,
+                endpoint_config=endpoint_config,
+                static_params={},
+                bookmark_query_field_from="modified__gte",
+                bookmark_query_field_to="modified__lte",
+                bookmark_field="modified",
+                bookmark_type="datetime",
+                data_key="results",
+                id_fields=["id"],
+                days_interval=3650,
+            )
+
+        self.assertEqual(mock_client.get.call_count, 3)
+        self.assertEqual(mock_write_record.call_count, 4)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,0 +1,164 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_saasoptics.discover import discover
+from tap_saasoptics.sync import sync_endpoint
+
+try:
+    from .base import SaaSOpticsBaseTest
+except ImportError:
+    from base import SaaSOpticsBaseTest
+
+
+class StartDateIntegrationTest(SaaSOpticsBaseTest, unittest.TestCase):
+    """
+    Integration tests that verify the tap uses `start_date` from the config
+    when no prior bookmark exists in state.
+    """
+
+    def _run_sync_endpoint_for_customers(self, state):
+        """Run sync_endpoint for the 'customers' stream with the given state."""
+        stream_name = "customers"
+        record = {"id": "1", "modified": "2025-02-01T00:00:00Z"}
+
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {"count": 1, "next": None, "results": [record]}
+
+        catalog = discover()
+
+        with patch("tap_saasoptics.sync.transform_json", return_value=[record]), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state=state,
+                start_date=self.config["start_date"],
+                stream_name=stream_name,
+                path=stream_name,
+                endpoint_config={
+                    "key_properties": ["id"],
+                    "replication_method": "INCREMENTAL",
+                    "replication_keys": ["modified"],
+                    "bookmark_query_field_from": "modified__gte",
+                    "bookmark_query_field_to": "modified__lte",
+                    "bookmark_type": "datetime",
+                },
+                static_params={},
+                bookmark_query_field_from="modified__gte",
+                bookmark_query_field_to="modified__lte",
+                bookmark_field="modified",
+                bookmark_type="datetime",
+                data_key="results",
+                id_fields=["id"],
+                days_interval=3650,
+            )
+
+        return mock_client
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_start_date_used_as_window_start_when_no_bookmark(self):
+        """
+        When no bookmark exists the query param must equal start_date.
+        """
+        mock_client = self._run_sync_endpoint_for_customers(state={})
+
+        call_kwargs = mock_client.get.call_args
+        params_str = (
+            call_kwargs.kwargs.get("params") or call_kwargs[1].get("params", "")
+        ) or ""
+
+        self.assertIn(
+            "modified__gte",
+            str(params_str),
+            msg="modified__gte was not sent when no bookmark exists",
+        )
+        # The year from the default start date must appear in the query
+        start_year = self.default_start_date[:4]
+        self.assertIn(
+            start_year,
+            str(params_str),
+            msg="start_date year was not found in the modified__gte query param",
+        )
+
+    def test_state_initialised_with_start_date_when_no_bookmark(self):
+        """
+        After syncing from scratch the bookmark written to state must equal
+        the max record value (which is >= start_date).
+        """
+        state = {}
+        self._run_sync_endpoint_for_customers(state)
+
+        new_bookmark = state.get("bookmarks", {}).get("customers")
+        self.assertIsNotNone(
+            new_bookmark,
+            msg="No bookmark was written to state after initial sync",
+        )
+        self.assertGreaterEqual(
+            new_bookmark,
+            self.default_start_date,
+            msg="Initial bookmark must not be before start_date",
+        )
+
+    def test_custom_start_date_is_respected(self):
+        """
+        Changing start_date in config must change the query window when no
+        prior bookmark exists.
+        """
+        self.config["start_date"] = "2025-06-15T00:00:00Z"
+
+        stream_name = "customers"
+        record = {"id": "1", "modified": "2025-07-01T00:00:00Z"}
+
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {"count": 1, "next": None, "results": [record]}
+
+        catalog = discover()
+
+        with patch("tap_saasoptics.sync.transform_json", return_value=[record]), \
+             patch("tap_saasoptics.sync.singer.write_state"), \
+             patch("tap_saasoptics.sync.write_schema"):
+            sync_endpoint(
+                client=mock_client,
+                catalog=catalog,
+                state={},
+                start_date=self.config["start_date"],
+                stream_name=stream_name,
+                path=stream_name,
+                endpoint_config={
+                    "key_properties": ["id"],
+                    "replication_method": "INCREMENTAL",
+                    "replication_keys": ["modified"],
+                    "bookmark_query_field_from": "modified__gte",
+                    "bookmark_query_field_to": "modified__lte",
+                    "bookmark_type": "datetime",
+                },
+                static_params={},
+                bookmark_query_field_from="modified__gte",
+                bookmark_query_field_to="modified__lte",
+                bookmark_field="modified",
+                bookmark_type="datetime",
+                data_key="results",
+                id_fields=["id"],
+                days_interval=3650,
+            )
+
+        call_kwargs = mock_client.get.call_args_list[0]
+        params_str = (
+            call_kwargs.kwargs.get("params") or call_kwargs[1].get("params", "")
+        ) or ""
+
+        self.assertIn(
+            "2025-06-15",
+            str(params_str),
+            msg="Custom start_date was not reflected in the first API request",
+        )

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,224 @@
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import requests
+
+from tap_saasoptics.client import (
+    SaaSOpticsClient,
+    SaaSOpticsBadRequestError,
+    SaaSOpticsConflictError,
+    SaaSOpticsUnauthorizedError,
+    SaaSOpticsForbiddenError,
+    SaaSOpticsNotFoundError,
+    SaaSOpticsInternalServiceError,
+    SaaSOpticsError,
+    Server5xxError,
+    raise_for_error,
+    get_exception_for_error_code,
+)
+
+
+class TestGetExceptionForErrorCode(unittest.TestCase):
+    """Unit tests for the error-code → exception-class mapping."""
+
+    def test_400_maps_to_bad_request(self):
+        self.assertIs(get_exception_for_error_code(400), SaaSOpticsBadRequestError)
+
+    def test_401_maps_to_unauthorized(self):
+        self.assertIs(get_exception_for_error_code(401), SaaSOpticsUnauthorizedError)
+
+    def test_403_maps_to_forbidden(self):
+        self.assertIs(get_exception_for_error_code(403), SaaSOpticsForbiddenError)
+
+    def test_404_maps_to_not_found(self):
+        self.assertIs(get_exception_for_error_code(404), SaaSOpticsNotFoundError)
+    
+    def test_409_maps_to_conflict(self):
+        self.assertIs(get_exception_for_error_code(409), SaaSOpticsConflictError)
+
+    def test_500_maps_to_internal_service_error(self):
+        self.assertIs(
+            get_exception_for_error_code(500), SaaSOpticsInternalServiceError
+        )
+
+    def test_unknown_code_maps_to_base_error(self):
+        self.assertIs(get_exception_for_error_code(418), SaaSOpticsError)
+
+
+class TestRaiseForError(unittest.TestCase):
+    """Unit tests for raise_for_error()."""
+
+    def _make_response(self, status_code, json_body=None, content=b"error"):
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = status_code
+        resp.content = content
+        resp.json.return_value = json_body or {}
+        http_error = requests.HTTPError(response=resp)
+        resp.raise_for_status.side_effect = http_error
+        return resp
+
+    def test_empty_content_does_not_raise(self):
+        """An empty response body should be silently ignored."""
+        resp = self._make_response(400, content=b"")
+        # Should not raise
+        raise_for_error(resp)
+
+    def test_raises_saasoptics_error_on_unknown_json(self):
+        """An unrecognised JSON payload should raise SaaSOpticsError."""
+        resp = self._make_response(400, json_body={"other": "field"})
+        with self.assertRaises(SaaSOpticsError):
+            raise_for_error(resp)
+
+    def test_raises_correct_exception_for_error_json(self):
+        """A JSON body with 'error' / 'message' fields must map to the right exception."""
+        resp = self._make_response(
+            401,
+            json_body={"error": {"code": 401}, "message": "Unauthorized"},
+        )
+        with self.assertRaises(SaaSOpticsError):
+            raise_for_error(resp)
+
+
+class TestSaaSOpticsClientCheckToken(unittest.TestCase):
+    """Unit tests for SaaSOpticsClient.check_token()."""
+
+    def _make_client(self):
+        return SaaSOpticsClient(
+            token="test-token",
+            account_name="test-account",
+            server_subdomain="test-subdomain",
+            user_agent="test-agent/1.0",
+        )
+
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_check_token_returns_true_on_success(self, mock_session_cls):
+        """check_token() must return True when the API returns 200 with results."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": [{"id": 1}]}
+        mock_session.get.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        result = client.check_token()
+        self.assertTrue(result)
+
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_check_token_returns_false_when_no_results_key(self, mock_session_cls):
+        """check_token() must return False when response has no 'results' key."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+        mock_session.get.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        result = client.check_token()
+        self.assertFalse(result)
+
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_check_token_raises_on_non_200(self, mock_session_cls):
+        """check_token() must raise when the API responds with a non-200 status."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.content = b"Unauthorized"
+        mock_response.json.return_value = {}
+        http_error = requests.HTTPError(response=mock_response)
+        mock_response.raise_for_status.side_effect = http_error
+        mock_session.get.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        with self.assertRaises(Exception):
+            client.check_token()
+
+
+class TestSaaSOpticsClientRequest(unittest.TestCase):
+    """Unit tests for SaaSOpticsClient.request()."""
+
+    def _make_verified_client(self):
+        """Return a client instance already marked as verified."""
+        client = SaaSOpticsClient(
+            token="test-token",
+            account_name="test-account",
+            server_subdomain="test-subdomain",
+            user_agent="test-agent/1.0",
+        )
+        client._SaaSOpticsClient__verified = True
+        return client
+
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_request_returns_json_on_200(self, mock_session_cls):
+        """request() must return the parsed JSON body on a 200 response."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"count": 1, "results": []}
+        mock_session.request.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_verified_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        result = client.request("GET", url="https://example.com/api/v1.0/customers/")
+        self.assertEqual(result, {"count": 1, "results": []})
+
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_request_raises_server5xx_error_on_500(self, mock_session_cls):
+        """request() must raise Server5xxError for any 5xx status code."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_session.request.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_verified_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        with self.assertRaises(Server5xxError):
+            client.request("GET", url="https://example.com/api/v1.0/customers/")
+
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_request_raises_for_4xx_error(self, mock_session_cls):
+        """request() must raise a SaaSOpticsError subclass for 4xx responses."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.content = b"Not Found"
+        mock_response.json.return_value = {}
+        http_error = requests.HTTPError(response=mock_response)
+        mock_response.raise_for_status.side_effect = http_error
+        mock_session.request.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_verified_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        with self.assertRaises(SaaSOpticsError):
+            client.request("GET", url="https://example.com/api/v1.0/unknown/")
+
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_get_delegates_to_request(self, mock_session_cls):
+        """client.get() must call client.request() with method='GET'."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_session.request.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_verified_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        client.get(path="billing_descriptions", url="https://example.com/api/v1.0/billing_descriptions/")
+        call_args = mock_session.request.call_args
+        self.assertEqual(call_args[0][0], "GET")

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -141,6 +141,21 @@ class TestSaaSOpticsClientCheckToken(unittest.TestCase):
         with self.assertRaises(Exception):
             client.check_token()
 
+    @patch("tap_saasoptics.client.requests.Session")
+    def test_check_token_raises_clear_error_on_connection_failure(self, mock_session_cls):
+        """check_token() should raise a clear SaaSOpticsError on TLS/connection failures."""
+        mock_session = MagicMock()
+        mock_session.get.side_effect = requests.exceptions.SSLError("handshake failure")
+        mock_session_cls.return_value = mock_session
+
+        client = self._make_client()
+        client._SaaSOpticsClient__session = mock_session
+
+        with self.assertRaises(SaaSOpticsError) as caught:
+            client.check_token()
+
+        self.assertIn('Failed to validate SaaSOptics credentials and API endpoint', str(caught.exception))
+
 
 class TestSaaSOpticsClientRequest(unittest.TestCase):
     """Unit tests for SaaSOpticsClient.request()."""

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -154,7 +154,10 @@ class TestSaaSOpticsClientCheckToken(unittest.TestCase):
         with self.assertRaises(SaaSOpticsError) as caught:
             client.check_token()
 
-        self.assertIn('Failed to validate SaaSOptics credentials and API endpoint', str(caught.exception))
+        self.assertIn(
+            'Invalid SaaSOptics credentials or API endpoint. Check token, account_name, server_subdomain, and network config.',
+            str(caught.exception),
+        )
 
 
 class TestSaaSOpticsClientRequest(unittest.TestCase):

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,21 @@
+import unittest
+
+from tap_saasoptics.discover import discover
+from tap_saasoptics.streams import STREAMS
+
+
+class TestDiscover(unittest.TestCase):
+    """Unit tests for discover()."""
+
+    def test_discover_returns_catalog_with_all_streams(self):
+        """discover() must return a Catalog containing all STREAMS entries."""
+        catalog = discover()
+        stream_names = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(stream_names, set(STREAMS.keys()))
+
+    def test_discover_catalog_entry_stream_equals_tap_stream_id(self):
+        """CatalogEntry.stream must equal CatalogEntry.tap_stream_id."""
+        catalog = discover()
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                self.assertEqual(entry.stream, entry.tap_stream_id)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,17 +1,45 @@
 import unittest
+from unittest.mock import MagicMock
 
 from tap_saasoptics.discover import discover
+from tap_saasoptics.client import SaaSOpticsForbiddenError
 from tap_saasoptics.streams import STREAMS
 
 
 class TestDiscover(unittest.TestCase):
     """Unit tests for discover()."""
 
-    def test_discover_returns_catalog_with_all_streams(self):
+    def test_discover_returns_catalog_with_all_streams_without_client(self):
         """discover() must return a Catalog containing all STREAMS entries."""
         catalog = discover()
         stream_names = {s.tap_stream_id for s in catalog.streams}
         self.assertEqual(stream_names, set(STREAMS.keys()))
+
+    def test_discover_excludes_inaccessible_streams(self):
+        """discover(client) must exclude streams that raise forbidden."""
+        restricted_streams = {'customers', 'contracts'}
+
+        mock_client = MagicMock()
+
+        def _get_side_effect(path, **_kwargs):
+            if path in restricted_streams:
+                raise SaaSOpticsForbiddenError('Forbidden')
+            return {'results': []}
+
+        mock_client.get.side_effect = _get_side_effect
+
+        catalog = discover(mock_client)
+        stream_names = {s.tap_stream_id for s in catalog.streams}
+
+        self.assertEqual(stream_names, set(STREAMS.keys()) - restricted_streams)
+
+    def test_discover_raises_when_no_stream_is_accessible(self):
+        """discover(client) must fail if all streams are inaccessible."""
+        mock_client = MagicMock()
+        mock_client.get.side_effect = SaaSOpticsForbiddenError('Forbidden')
+
+        with self.assertRaises(SaaSOpticsForbiddenError):
+            discover(mock_client)
 
     def test_discover_catalog_entry_stream_equals_tap_stream_id(self):
         """CatalogEntry.stream must equal CatalogEntry.tap_stream_id."""

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,7 +1,11 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from tap_saasoptics.discover import discover
+from tap_saasoptics.discover import (
+    discover,
+    _check_stream_access,
+    _apply_access_checks,
+)
 from tap_saasoptics.client import SaaSOpticsForbiddenError
 from tap_saasoptics.streams import STREAMS
 
@@ -47,3 +51,69 @@ class TestDiscover(unittest.TestCase):
         for entry in catalog.streams:
             with self.subTest(stream=entry.tap_stream_id):
                 self.assertEqual(entry.stream, entry.tap_stream_id)
+
+
+class TestAccessChecks(unittest.TestCase):
+    """Unit tests for discovery access-check helpers."""
+
+    def test_check_stream_access_returns_false_and_logs_on_forbidden(self):
+        """_check_stream_access() should return False and log warning on 403."""
+        client = MagicMock()
+        client.get.side_effect = SaaSOpticsForbiddenError('Forbidden')
+
+        with patch('tap_saasoptics.discover.LOGGER') as mock_logger:
+            result = _check_stream_access(client, 'customers', {'path': 'customers'})
+
+        self.assertFalse(result)
+        mock_logger.warning.assert_called_once_with(
+            "No 'read' access to stream '%s'. Excluded from catalog.",
+            'customers',
+        )
+
+    def test_apply_access_checks_includes_pruned_children_in_consolidated_warning(self):
+        """Consolidated warning should include inaccessible parents and pruned child streams."""
+        client = MagicMock()
+        schemas = {'parent_stream': {}, 'child_stream': {}, 'other_stream': {}}
+        field_metadata = {'parent_stream': [], 'child_stream': [], 'other_stream': []}
+
+        test_streams = {
+            'parent_stream': {'path': 'parent_stream'},
+            'child_stream': {'path': 'child_stream', 'parent': 'parent_stream'},
+            'other_stream': {'path': 'other_stream'},
+        }
+
+        with patch('tap_saasoptics.discover.STREAMS', test_streams), \
+             patch('tap_saasoptics.discover._check_stream_access') as mock_check, \
+             patch('tap_saasoptics.discover.LOGGER') as mock_logger:
+            mock_check.side_effect = lambda _client, stream_name, _cfg: stream_name != 'parent_stream'
+
+            _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertNotIn('parent_stream', schemas)
+        self.assertNotIn('child_stream', schemas)
+        self.assertIn('other_stream', schemas)
+
+        warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+        self.assertTrue(any("No 'read' access to stream(s):" in call for call in warning_calls))
+        self.assertTrue(any('parent_stream, child_stream' in call for call in warning_calls))
+
+    def test_apply_access_checks_raises_with_expected_message_when_no_stream_access(self):
+        """No accessible streams should raise exact 403 error message."""
+        client = MagicMock()
+        schemas = {'customers': {}, 'contracts': {}}
+        field_metadata = {'customers': [], 'contracts': []}
+
+        test_streams = {
+            'customers': {'path': 'customers'},
+            'contracts': {'path': 'contracts'},
+        }
+
+        with patch('tap_saasoptics.discover.STREAMS', test_streams), \
+             patch('tap_saasoptics.discover._check_stream_access', return_value=False):
+            with self.assertRaises(SaaSOpticsForbiddenError) as ctx:
+                _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertEqual(
+            str(ctx.exception),
+            "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams.",
+        )

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -66,8 +66,9 @@ class TestAccessChecks(unittest.TestCase):
 
         self.assertFalse(result)
         mock_logger.warning.assert_called_once_with(
-            "No 'read' access to stream '%s'. Excluded from catalog.",
+            "Excluding unauthorized stream '%s' from catalog. API error: %s",
             'customers',
+            client.get.side_effect,
         )
 
     def test_apply_access_checks_includes_pruned_children_in_consolidated_warning(self):
@@ -94,7 +95,7 @@ class TestAccessChecks(unittest.TestCase):
         self.assertIn('other_stream', schemas)
 
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
-        self.assertTrue(any("No 'read' access to stream(s):" in call for call in warning_calls))
+        self.assertTrue(any("Excluding unauthorized stream(s) from catalog:" in call for call in warning_calls))
         self.assertTrue(any('parent_stream, child_stream' in call for call in warning_calls))
 
     def test_apply_access_checks_raises_with_expected_message_when_no_stream_access(self):

--- a/tests/unittests/test_schema.py
+++ b/tests/unittests/test_schema.py
@@ -1,0 +1,33 @@
+import unittest
+
+from singer import metadata
+
+from tap_saasoptics.schema import get_schemas
+from tap_saasoptics.streams import STREAMS
+
+
+class TestSchemaMetadata(unittest.TestCase):
+    def test_replication_keys_are_automatic(self):
+        _schemas, field_metadata = get_schemas()
+
+        for stream_name, stream_config in STREAMS.items():
+            replication_keys = stream_config.get("replication_keys", []) or []
+            if not replication_keys:
+                continue
+
+            metadata_map = metadata.to_map(field_metadata[stream_name])
+            for replication_key in replication_keys:
+                breadcrumb = ("properties", replication_key)
+                inclusion = metadata_map.get(breadcrumb, {}).get("inclusion")
+                self.assertEqual(
+                    inclusion,
+                    "automatic",
+                    msg=(
+                        f"stream={stream_name}, replication_key={replication_key}, "
+                        f"inclusion={inclusion}"
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,344 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+from singer.utils import strptime_to_utc, strftime
+
+from tap_saasoptics.sync import (
+    get_bookmark,
+    write_bookmark,
+    process_records,
+    update_currently_syncing,
+    sync_endpoint,
+    sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_bookmark
+# ---------------------------------------------------------------------------
+
+class TestGetBookmark(unittest.TestCase):
+    """Unit tests for get_bookmark()."""
+
+    def test_returns_default_when_state_is_empty(self):
+        self.assertEqual(
+            get_bookmark({}, "customers", "2025-01-01T00:00:00Z"),
+            "2025-01-01T00:00:00Z",
+        )
+
+    def test_returns_default_when_no_bookmarks_key(self):
+        self.assertEqual(
+            get_bookmark({"other": "value"}, "customers", "2025-01-01T00:00:00Z"),
+            "2025-01-01T00:00:00Z",
+        )
+
+    def test_returns_default_when_stream_not_bookmarked(self):
+        state = {"bookmarks": {"other_stream": "2025-03-01T00:00:00Z"}}
+        self.assertEqual(
+            get_bookmark(state, "customers", "2025-01-01T00:00:00Z"),
+            "2025-01-01T00:00:00Z",
+        )
+
+    def test_returns_existing_bookmark(self):
+        state = {"bookmarks": {"customers": "2025-06-01T00:00:00Z"}}
+        self.assertEqual(
+            get_bookmark(state, "customers", "2025-01-01T00:00:00Z"),
+            "2025-06-01T00:00:00Z",
+        )
+
+    def test_returns_none_when_state_is_none(self):
+        self.assertIsNone(get_bookmark(None, "customers", None))
+
+
+# ---------------------------------------------------------------------------
+# write_bookmark
+# ---------------------------------------------------------------------------
+
+class TestWriteBookmark(unittest.TestCase):
+    """Unit tests for write_bookmark()."""
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    def test_creates_bookmarks_key_if_missing(self, _mock_write_state):
+        state = {}
+        write_bookmark(state, "customers", "2025-05-01T00:00:00Z")
+        self.assertIn("bookmarks", state)
+        self.assertEqual(state["bookmarks"]["customers"], "2025-05-01T00:00:00Z")
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    def test_overwrites_existing_bookmark(self, _mock_write_state):
+        state = {"bookmarks": {"customers": "2025-01-01T00:00:00Z"}}
+        write_bookmark(state, "customers", "2025-09-01T00:00:00Z")
+        self.assertEqual(state["bookmarks"]["customers"], "2025-09-01T00:00:00Z")
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    def test_calls_singer_write_state(self, mock_write_state):
+        state = {}
+        write_bookmark(state, "customers", "2025-05-01T00:00:00Z")
+        mock_write_state.assert_called_once_with(state)
+
+
+# ---------------------------------------------------------------------------
+# process_records
+# ---------------------------------------------------------------------------
+
+class TestProcessRecords(unittest.TestCase):
+    """Unit tests for process_records()."""
+
+    def _make_catalog(self, stream_name):
+        """Return a minimal mock catalog for process_records()."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "modified": {"type": "string", "format": "date-time"},
+                "name": {"type": "string"},
+            },
+        }
+        stream = MagicMock()
+        stream.schema.to_dict.return_value = schema
+        stream.metadata = []
+
+        catalog = MagicMock()
+        catalog.get_stream.return_value = stream
+        return catalog
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_writes_all_records_for_full_table(self, mock_write_record):
+        """FULL_TABLE: all records must be written regardless of bookmark."""
+        catalog = self._make_catalog("accounts")
+        records = [
+            {"id": "1", "name": "Acme"},
+            {"id": "2", "name": "Beta"},
+        ]
+        from singer.utils import now
+        max_bv, count = process_records(
+            catalog=catalog,
+            stream_name="accounts",
+            records=records,
+            time_extracted=now(),
+            bookmark_field=None,
+            bookmark_type=None,
+            max_bookmark_value=None,
+            last_datetime=None,
+            last_integer=None,
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(mock_write_record.call_count, 2)
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_filters_records_before_last_datetime(self, mock_write_record):
+        """INCREMENTAL (datetime): records before last_datetime must be skipped."""
+        catalog = self._make_catalog("customers")
+        records = [
+            {"id": "1", "modified": "2024-12-01T00:00:00Z"},  # before bookmark → skip
+            {"id": "2", "modified": "2025-03-01T00:00:00Z"},  # after → include
+            {"id": "3", "modified": "2025-06-01T00:00:00Z"},  # after → include
+        ]
+        from singer.utils import now
+        _max_bv, count = process_records(
+            catalog=catalog,
+            stream_name="customers",
+            records=records,
+            time_extracted=now(),
+            bookmark_field="modified",
+            bookmark_type="datetime",
+            max_bookmark_value="2025-01-01T00:00:00Z",
+            last_datetime="2025-01-01T00:00:00Z",
+            last_integer=None,
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(mock_write_record.call_count, 2)
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_max_bookmark_value_is_advanced(self, _mock_write_record):
+        """process_records() must return the highest bookmark seen across records."""
+        catalog = self._make_catalog("customers")
+        records = [
+            {"id": "1", "modified": "2025-02-01T00:00:00Z"},
+            {"id": "2", "modified": "2025-05-01T00:00:00Z"},
+            {"id": "3", "modified": "2025-03-01T00:00:00Z"},
+        ]
+        from singer.utils import now
+        max_bv, _ = process_records(
+            catalog=catalog,
+            stream_name="customers",
+            records=records,
+            time_extracted=now(),
+            bookmark_field="modified",
+            bookmark_type="datetime",
+            max_bookmark_value="2025-01-01T00:00:00Z",
+            last_datetime="2025-01-01T00:00:00Z",
+            last_integer=None,
+        )
+        self.assertGreaterEqual(max_bv, "2025-05-01")
+
+    @patch("tap_saasoptics.sync.write_record")
+    def test_empty_records_returns_zero_count(self, _mock_write_record):
+        catalog = self._make_catalog("customers")
+        from singer.utils import now
+        _max_bv, count = process_records(
+            catalog=catalog,
+            stream_name="customers",
+            records=[],
+            time_extracted=now(),
+            bookmark_field="modified",
+            bookmark_type="datetime",
+            max_bookmark_value="2025-01-01T00:00:00Z",
+            last_datetime="2025-01-01T00:00:00Z",
+            last_integer=None,
+        )
+        self.assertEqual(count, 0)
+
+
+# ---------------------------------------------------------------------------
+# update_currently_syncing
+# ---------------------------------------------------------------------------
+
+class TestUpdateCurrentlySyncing(unittest.TestCase):
+    """Unit tests for update_currently_syncing()."""
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    def test_sets_currently_syncing(self, _mock_write_state):
+        state = {}
+        update_currently_syncing(state, "customers")
+        self.assertEqual(state.get("currently_syncing"), "customers")
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    def test_clears_currently_syncing_when_none(self, _mock_write_state):
+        state = {"currently_syncing": "customers"}
+        update_currently_syncing(state, None)
+        self.assertNotIn("currently_syncing", state)
+
+
+# ---------------------------------------------------------------------------
+# sync_endpoint – no data case
+# ---------------------------------------------------------------------------
+
+class TestSyncEndpointNoData(unittest.TestCase):
+    """Unit tests for the no-data early-exit path in sync_endpoint()."""
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.write_schema")
+    def test_returns_zero_when_api_returns_no_data(
+        self, _mock_write_schema, _mock_write_state
+    ):
+        mock_client = MagicMock()
+        mock_client.base_url = (
+            "https://dummy-subdomain.saasoptics.com/dummy-account/api/v1.0"
+        )
+        mock_client.get.return_value = {}
+
+        from tap_saasoptics.discover import discover
+        catalog = discover()
+
+        total = sync_endpoint(
+            client=mock_client,
+            catalog=catalog,
+            state={},
+            start_date="2025-01-01T00:00:00Z",
+            stream_name="accounts",
+            path="accounts",
+            endpoint_config={"key_properties": ["id"], "replication_method": "FULL_TABLE"},
+            static_params={},
+            bookmark_query_field_from=None,
+            bookmark_query_field_to=None,
+            bookmark_field=None,
+            bookmark_type=None,
+            data_key="results",
+            id_fields=["id"],
+            days_interval=60,
+        )
+
+        self.assertEqual(total, 0)
+
+
+# ---------------------------------------------------------------------------
+# sync – top-level orchestration
+# ---------------------------------------------------------------------------
+
+class TestSync(unittest.TestCase):
+    """Unit tests for the top-level sync() function."""
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.update_currently_syncing")
+    @patch("tap_saasoptics.sync.sync_endpoint")
+    def test_sync_calls_sync_endpoint_for_each_selected_stream(
+        self, mock_sync_endpoint, mock_update_syncing, _mock_write_state
+    ):
+        """sync() must call sync_endpoint exactly once per selected stream."""
+        mock_sync_endpoint.return_value = 0
+
+        stream_a = MagicMock()
+        stream_a.stream = "customers"
+        stream_b = MagicMock()
+        stream_b.stream = "contracts"
+
+        catalog = MagicMock()
+        catalog.get_selected_streams.return_value = [stream_a, stream_b]
+
+        config = {
+            "token": "dummy",
+            "account_name": "acc",
+            "server_subdomain": "sub",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+
+        mock_client = MagicMock()
+        sync(client=mock_client, config=config, catalog=catalog, state={})
+
+        self.assertEqual(mock_sync_endpoint.call_count, 2)
+        synced = {c.kwargs["stream_name"] for c in mock_sync_endpoint.call_args_list}
+        self.assertEqual(synced, {"customers", "contracts"})
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.sync_endpoint")
+    def test_sync_does_nothing_when_no_streams_selected(
+        self, mock_sync_endpoint, _mock_write_state
+    ):
+        """sync() must not call sync_endpoint when no streams are selected."""
+        catalog = MagicMock()
+        catalog.get_selected_streams.return_value = []
+
+        config = {
+            "token": "dummy",
+            "account_name": "acc",
+            "server_subdomain": "sub",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+
+        mock_client = MagicMock()
+        sync(client=mock_client, config=config, catalog=catalog, state={})
+
+        mock_sync_endpoint.assert_not_called()
+
+    @patch("tap_saasoptics.sync.singer.write_state")
+    @patch("tap_saasoptics.sync.update_currently_syncing")
+    @patch("tap_saasoptics.sync.sync_endpoint")
+    def test_currently_syncing_cleared_after_each_stream(
+        self, mock_sync_endpoint, mock_update_syncing, _mock_write_state
+    ):
+        """
+        sync() must call update_currently_syncing(state, None) after each
+        stream to clear the currently_syncing flag.
+        """
+        mock_sync_endpoint.return_value = 0
+
+        stream_a = MagicMock()
+        stream_a.stream = "customers"
+
+        catalog = MagicMock()
+        catalog.get_selected_streams.return_value = [stream_a]
+
+        config = {
+            "token": "dummy",
+            "account_name": "acc",
+            "server_subdomain": "sub",
+            "start_date": "2025-01-01T00:00:00Z",
+        }
+
+        mock_client = MagicMock()
+        sync(client=mock_client, config=config, catalog=catalog, state={})
+
+        # update_currently_syncing called with stream name, then with None
+        calls = mock_update_syncing.call_args_list
+        self.assertEqual(calls[0], call({}, "customers"))
+        self.assertEqual(calls[1], call({}, None))


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31239

## Summary
This PR adds discovery-time stream access filtering to `tap-saasoptics` so inaccessible streams are excluded from the catalog, while preserving existing behavior when no client is provided.

## What changed
- Updated discovery to support `discover(client=None)`:
  - Probes stream access via lightweight `GET` calls.
  - Excludes streams that return `SaaSOpticsForbiddenError`.
  - Logs excluded stream names.
  - Raises `SaaSOpticsForbiddenError` if no streams are accessible.
- Wired discover mode to pass the authenticated client into discovery (`do_discover(client)`).
- Added unit coverage for discovery access behavior:
  - Returns all streams without a client.
  - Excludes only forbidden streams with a client.
  - Fails when all streams are forbidden.
- Updated release metadata:
  - Version bumped to `1.3.0`.
  - Changelog entry added for stream exclusion behavior.

## Why
Some SaaSOptics accounts have partial API permissions. This prevents discovery from failing entirely when only some streams are restricted, while still failing clearly when nothing is accessible.

## Validation
Ran targeted unit tests:
- `../env/Scripts/python.exe -m pytest tests/unittests/test_discover.py tests/unittests/test_client.py tests/unittests/test_sync.py`

Result:
- `39 passed` (with existing deprecation warnings unrelated to this change)

## Notes
- Backward compatibility is preserved for callers that use `discover()` without a client.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
